### PR TITLE
Refresh token handling + various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,15 @@ Setup instructions
 Creating a token:
 
 1. Ensure the process is running and configured with your credentials in `./.config.js`
-2. Visit `http://localhost:4000/` and click "Testify!", this should bring you to the authorization screen
+2. Visit `http://localhost:4000/` and click the link to authorize your integration
 3. Add your desired resources, then click authorize.
-4. Your OAuth Access token should be viewable in the terminal running the server
+4. The response, including your access token and refresh token, should be visible
+
+Refreshing a token:
+1. Ensure the process is running and configured with your credentials in `./.config.js`
+2. Ensure you have a refresh token (obtainable by creating a token, see above)
+3. Visit `http://localhost:4000/` and enter your refresh token to the input field and click "submit"
+4. The response, including your new access token and refresh token, should be visible
+
 
 You can read more [in the docs](https://airtable.com/oauth-beta-developer-reference).

--- a/index.js
+++ b/index.js
@@ -177,6 +177,7 @@ app.get('/airtable-oauth', (req, res) => {
 app.get('/refresh_token_form', (req, res) => {
     const latestRequestStateDisplayData = formatLatestTokenRequestStateForDeveloper();
 
+    // double clicking submit may cause a token revocation
     res.send(`<div>
         ${latestRequestStateDisplayData}
         <p>To Refresh a token, enter it into the input and press "submit"</p>

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const airtableUrl = config.airtableUrl.trim();
 const encodedCredentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
 const authorizationHeader = `Basic ${encodedCredentials}`;
 
-// book keeping to using this easier, not needed in a real implementation
+// book keeping to make using this easier, not needed in a real implementation
 setLatestTokenRequestState('NONE');
 
 app.get('/', (req, res) => {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,11 @@ app.get('/', (req, res) => {
     <br/>
     <h3>Refresh a token</h3>
     ${latestRequestStateDisplayData}
-    <p>To Refresh a token, enter it into the input and press "submit"</p>
+    <p>
+        To test refreshing a token, enter it into the input and press "submit"
+        <br/>
+        In your own code, refreshing should occur as a background process.
+    </p>
     <form action="/refresh_token" method="post" >
         <label for="refresh">Refresh token:
         <input type="text" id="refresh" name="refresh_token" autocomplete="off" minLength="64"/>


### PR DESCRIPTION
Made some improvements while working on an unrelated change, it's easier to test the refresh flow now. See screenshots to see the visual improvements (all tokens are already revoked):

## Open the page
<img width="479" alt="Screenshot 2023-04-01 at 2 17 06 PM" src="https://user-images.githubusercontent.com/98786386/229314359-bfa0bb47-2219-48d2-ac57-74b5a45e7dc6.png">

## Begin authorization

<img width="612" alt="Screenshot 2023-04-01 at 2 17 39 PM" src="https://user-images.githubusercontent.com/98786386/229314362-28d620ef-b931-441e-acdf-bdc30a58c438.png">

## Authorize, see response
<img width="476" alt="Screenshot 2023-04-01 at 2 17 54 PM" src="https://user-images.githubusercontent.com/98786386/229314364-9d1dd870-6b84-4c20-a237-7eab274f3648.png">

## Refresh a token successfully
<img width="473" alt="Screenshot 2023-04-01 at 2 18 17 PM" src="https://user-images.githubusercontent.com/98786386/229314368-b13ae528-e898-4a23-badd-4c1b4be109a7.png">

## Fail to refresh a token
<img width="468" alt="Screenshot 2023-04-01 at 2 18 59 PM" src="https://user-images.githubusercontent.com/98786386/229314372-fb66b1a7-8170-48e7-816d-990edab7c328.png">
